### PR TITLE
fix: debug footer not displaying correctly

### DIFF
--- a/packages/cloudflare-agent/src/agents/router-agent.ts
+++ b/packages/cloudflare-agent/src/agents/router-agent.ts
@@ -466,7 +466,20 @@ export function createRouterAgent<TEnv extends RouterAgentEnv>(
           });
         }
 
-        return result;
+        // Step 9: Enhance result with routing metadata for debug footer
+        return {
+          ...result,
+          data: {
+            ...(result.data && typeof result.data === 'object' ? result.data : {}),
+            routedTo: target,
+            classification: {
+              type: classification.type,
+              category: classification.category,
+              complexity: classification.complexity,
+            },
+            routerDurationMs: classificationMs,
+          },
+        };
       } catch (error) {
         const durationMs = Date.now() - startTime;
 


### PR DESCRIPTION
The debug footer was not showing because StepProgressTracker methods (startRouter, completeRouter, completeTargetAgent) were never called, leaving routingFlow empty.

Changes:
- router-agent: Add routing metadata (routedTo, classification, routerDurationMs) to the result data so it can be extracted by CloudflareAgent
- cloudflare-agent: Call StepProgressTracker methods at appropriate points:
  - startRouter() before routing
  - completeRouter() with target agent and classification after routing
  - completeTargetAgent() after response is ready

This ensures the debug context is properly populated so admin users can see the routing flow, classification, and timing in the debug footer.

## Summary by Sourcery

Populate routing debug metadata so the debug footer can display router flow, classification, and timing for routed queries.

New Features:
- Include routing metadata (target agent, classification, and router duration) in RouterAgent results for downstream consumers.

Bug Fixes:
- Ensure StepProgressTracker router and target-agent steps are started and completed so the debug footer shows routing flow and timing.

Enhancements:
- Log routed responses with attached classification details for better observability.