### PR TITLE
feat(github-bot): support reviewer assignment webhook to trigger PR review

### DIFF
--- a/apps/github-bot/src/__tests__/mention-middleware.test.ts
+++ b/apps/github-bot/src/__tests__/mention-middleware.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Mention Middleware Tests
+ *
+ * Tests for mention detection middleware, including the review_requested bypass.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { createGitHubMentionMiddleware } from '../middlewares/mention.js';
+import type { Env, MentionVariables, WebhookContext } from '../middlewares/types.js';
+
+// Mock logger to prevent console output during tests
+vi.mock('@duyetbot/hono-middleware', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('createGitHubMentionMiddleware', () => {
+  const mockEnv: Env = {
+    GITHUB_TOKEN: 'test-token',
+    BOT_USERNAME: 'duyetbot',
+    GitHubAgent: {} as Env['GitHubAgent'],
+  };
+
+  const createTestApp = (webhookContext: WebhookContext | undefined, skipProcessing = false) => {
+    const app = new Hono<{ Bindings: Env; Variables: MentionVariables }>();
+
+    // Setup middleware to set initial context
+    app.use('*', async (c, next) => {
+      c.set('webhookContext', webhookContext);
+      c.set('skipProcessing', skipProcessing);
+      c.set('rawBody', '{}');
+      await next();
+    });
+
+    // Apply mention middleware
+    app.use('*', createGitHubMentionMiddleware());
+
+    // Test endpoint to capture results
+    app.post('/test', (c) => {
+      return c.json({
+        hasMention: c.get('hasMention'),
+        task: c.get('task'),
+        skipProcessing: c.get('skipProcessing'),
+      });
+    });
+
+    return app;
+  };
+
+  const makeRequest = async (app: ReturnType<typeof createTestApp>) => {
+    const res = await app.request(
+      '/test',
+      { method: 'POST' },
+      mockEnv // Pass env as the third argument
+    );
+    return res.json();
+  };
+
+  const baseContext: WebhookContext = {
+    owner: 'testowner',
+    repo: 'testrepo',
+    event: 'issue_comment',
+    action: 'created',
+    deliveryId: 'delivery-123',
+    requestId: 'req-abc',
+    sender: { login: 'testuser', id: 123 },
+    isPullRequest: false,
+  };
+
+  describe('review_requested events', () => {
+    it('should bypass mention check when bot is the requested reviewer', async () => {
+      const ctx: WebhookContext = {
+        ...baseContext,
+        event: 'pull_request',
+        action: 'review_requested',
+        isPullRequest: true,
+        isReviewRequest: true,
+        requestedReviewer: 'duyetbot',
+        issue: {
+          number: 42,
+          title: 'Test PR',
+          body: 'PR description',
+          state: 'open',
+        },
+      };
+
+      const app = createTestApp(ctx);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(true);
+      expect(data.task).toBe('Please review this pull request');
+      expect(data.skipProcessing).toBe(false);
+    });
+
+    it('should handle bot[bot] format username', async () => {
+      const ctx: WebhookContext = {
+        ...baseContext,
+        event: 'pull_request',
+        action: 'review_requested',
+        isPullRequest: true,
+        isReviewRequest: true,
+        requestedReviewer: 'duyetbot[bot]',
+        issue: {
+          number: 42,
+          title: 'Test PR',
+          body: 'PR description',
+          state: 'open',
+        },
+      };
+
+      const app = createTestApp(ctx);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(true);
+      expect(data.task).toBe('Please review this pull request');
+      expect(data.skipProcessing).toBe(false);
+    });
+
+    it('should be case insensitive for reviewer matching', async () => {
+      const ctx: WebhookContext = {
+        ...baseContext,
+        event: 'pull_request',
+        action: 'review_requested',
+        isPullRequest: true,
+        isReviewRequest: true,
+        requestedReviewer: 'DuyetBot',
+        issue: {
+          number: 42,
+          title: 'Test PR',
+          body: 'PR description',
+          state: 'open',
+        },
+      };
+
+      const app = createTestApp(ctx);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(true);
+      expect(data.task).toBe('Please review this pull request');
+    });
+
+    it('should skip processing when different user is requested reviewer', async () => {
+      const ctx: WebhookContext = {
+        ...baseContext,
+        event: 'pull_request',
+        action: 'review_requested',
+        isPullRequest: true,
+        isReviewRequest: true,
+        requestedReviewer: 'otheruser',
+        issue: {
+          number: 42,
+          title: 'Test PR',
+          body: 'PR description',
+          state: 'open',
+        },
+      };
+
+      const app = createTestApp(ctx);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(false);
+      expect(data.task).toBeUndefined();
+      expect(data.skipProcessing).toBe(true);
+    });
+  });
+
+  describe('regular mention events', () => {
+    it('should detect mention in comment', async () => {
+      const ctx: WebhookContext = {
+        ...baseContext,
+        comment: {
+          id: 100,
+          body: '@duyetbot please help me with this',
+        },
+      };
+
+      const app = createTestApp(ctx);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(true);
+      expect(data.task).toBe('please help me with this');
+      expect(data.skipProcessing).toBe(false);
+    });
+
+    it('should detect mention in issue body', async () => {
+      const ctx: WebhookContext = {
+        ...baseContext,
+        event: 'issues',
+        action: 'opened',
+        issue: {
+          number: 42,
+          title: 'Need help',
+          body: '@duyetbot can you review this issue?',
+          state: 'open',
+        },
+      };
+
+      const app = createTestApp(ctx);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(true);
+      expect(data.task).toBe('can you review this issue?');
+    });
+
+    it('should skip when no mention in text', async () => {
+      const ctx: WebhookContext = {
+        ...baseContext,
+        comment: {
+          id: 100,
+          body: 'Just a regular comment without mention',
+        },
+      };
+
+      const app = createTestApp(ctx);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(false);
+      expect(data.skipProcessing).toBe(true);
+    });
+
+    it('should process mention even when no explicit task (returns mention as task)', async () => {
+      // Note: extractTask returns the original text when parseMention fails to extract a task
+      // So '@duyetbot' alone returns '@duyetbot' as the task (not empty)
+      const ctx: WebhookContext = {
+        ...baseContext,
+        comment: {
+          id: 100,
+          body: '@duyetbot',
+        },
+      };
+
+      const app = createTestApp(ctx);
+      const data = await makeRequest(app);
+
+      // The current implementation treats '@duyetbot' alone as having a task
+      // because extractTask returns the original text when parseMention doesn't match
+      expect(data.hasMention).toBe(true);
+      expect(data.task).toBe('@duyetbot');
+      expect(data.skipProcessing).toBe(false);
+    });
+  });
+
+  describe('skip conditions', () => {
+    it('should skip when skipProcessing is already set', async () => {
+      const ctx: WebhookContext = {
+        ...baseContext,
+        comment: {
+          id: 100,
+          body: '@duyetbot help me',
+        },
+      };
+
+      const app = createTestApp(ctx, true);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(false);
+      expect(data.skipProcessing).toBe(true);
+    });
+
+    it('should skip when no webhook context', async () => {
+      const app = createTestApp(undefined);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(false);
+      expect(data.skipProcessing).toBe(true);
+    });
+
+    it('should skip when no text content in context', async () => {
+      const ctx: WebhookContext = {
+        ...baseContext,
+        // No comment or issue body
+      };
+
+      const app = createTestApp(ctx);
+      const data = await makeRequest(app);
+
+      expect(data.hasMention).toBe(false);
+      expect(data.skipProcessing).toBe(true);
+    });
+  });
+});

--- a/apps/github-bot/src/__tests__/parser.test.ts
+++ b/apps/github-bot/src/__tests__/parser.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Parser Middleware Tests
+ *
+ * Tests for webhook payload parsing, including the new review_requested event.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildWebhookContext, parseWebhookPayload } from '../middlewares/parser.js';
+import type { GitHubWebhookPayload } from '../middlewares/types.js';
+
+describe('parseWebhookPayload', () => {
+  it('should parse valid JSON payload', () => {
+    const rawBody = JSON.stringify({ action: 'created', sender: { login: 'user' } });
+    const result = parseWebhookPayload(rawBody);
+    expect(result).toEqual({ action: 'created', sender: { login: 'user' } });
+  });
+
+  it('should return null for invalid JSON', () => {
+    const result = parseWebhookPayload('not json');
+    expect(result).toBeNull();
+  });
+});
+
+describe('buildWebhookContext', () => {
+  const basePayload: GitHubWebhookPayload = {
+    action: 'created',
+    sender: { login: 'testuser', id: 123 },
+    repository: {
+      name: 'test-repo',
+      full_name: 'owner/test-repo',
+      owner: { login: 'owner', id: 1 },
+    },
+  };
+
+  describe('issue_comment events', () => {
+    it('should build context for issue comment', () => {
+      const payload: GitHubWebhookPayload = {
+        ...basePayload,
+        issue: {
+          number: 42,
+          title: 'Test Issue',
+          body: 'Issue body',
+          state: 'open',
+          labels: [{ name: 'bug' }],
+          html_url: 'https://github.com/owner/test-repo/issues/42',
+        },
+        comment: {
+          id: 100,
+          body: '@duyetbot help',
+          user: { login: 'commenter', id: 456 },
+          html_url: 'https://github.com/owner/test-repo/issues/42#comment-100',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      };
+
+      const ctx = buildWebhookContext(payload, 'issue_comment', 'delivery-123', 'req-abc');
+
+      expect(ctx.owner).toBe('owner');
+      expect(ctx.repo).toBe('test-repo');
+      expect(ctx.event).toBe('issue_comment');
+      expect(ctx.action).toBe('created');
+      expect(ctx.issue?.number).toBe(42);
+      expect(ctx.issue?.title).toBe('Test Issue');
+      expect(ctx.comment?.id).toBe(100);
+      expect(ctx.comment?.body).toBe('@duyetbot help');
+      expect(ctx.isPullRequest).toBe(false);
+      expect(ctx.isReviewRequest).toBeUndefined();
+    });
+
+    it('should detect PR from issue with pull_request property', () => {
+      const payload: GitHubWebhookPayload = {
+        ...basePayload,
+        issue: {
+          number: 42,
+          title: 'Test PR',
+          body: 'PR body',
+          state: 'open',
+          labels: [],
+          html_url: 'https://github.com/owner/test-repo/pull/42',
+          pull_request: { url: 'https://api.github.com/repos/owner/test-repo/pulls/42' },
+        },
+      };
+
+      const ctx = buildWebhookContext(payload, 'issue_comment', 'delivery-123', 'req-abc');
+      expect(ctx.isPullRequest).toBe(true);
+    });
+  });
+
+  describe('pull_request:review_requested events', () => {
+    it('should build context for review_requested event', () => {
+      const payload: GitHubWebhookPayload = {
+        ...basePayload,
+        action: 'review_requested',
+        pull_request: {
+          number: 99,
+          title: 'Add new feature',
+          body: 'This PR adds a new feature',
+          state: 'open',
+          labels: [{ name: 'enhancement' }],
+          html_url: 'https://github.com/owner/test-repo/pull/99',
+          additions: 100,
+          deletions: 20,
+          commits: 5,
+          changed_files: 10,
+          head: { ref: 'feature-branch', sha: 'abc123' },
+          base: { ref: 'main' },
+        },
+        requested_reviewer: { login: 'duyetbot', id: 789 },
+      };
+
+      const ctx = buildWebhookContext(payload, 'pull_request', 'delivery-456', 'req-def');
+
+      expect(ctx.owner).toBe('owner');
+      expect(ctx.repo).toBe('test-repo');
+      expect(ctx.event).toBe('pull_request');
+      expect(ctx.action).toBe('review_requested');
+      expect(ctx.isPullRequest).toBe(true);
+      expect(ctx.isReviewRequest).toBe(true);
+      expect(ctx.requestedReviewer).toBe('duyetbot');
+
+      // Issue context should be populated from PR data
+      expect(ctx.issue?.number).toBe(99);
+      expect(ctx.issue?.title).toBe('Add new feature');
+      expect(ctx.issue?.body).toBe('This PR adds a new feature');
+      expect(ctx.issue?.state).toBe('open');
+
+      // PR metadata should be extracted
+      expect(ctx.additions).toBe(100);
+      expect(ctx.deletions).toBe(20);
+      expect(ctx.commits).toBe(5);
+      expect(ctx.changedFiles).toBe(10);
+      expect(ctx.headRef).toBe('feature-branch');
+      expect(ctx.baseRef).toBe('main');
+
+      // No comment for review requests
+      expect(ctx.comment).toBeUndefined();
+    });
+
+    it('should handle review_requested without requested_reviewer', () => {
+      const payload: GitHubWebhookPayload = {
+        ...basePayload,
+        action: 'review_requested',
+        pull_request: {
+          number: 99,
+          title: 'Add new feature',
+          body: null,
+          state: 'open',
+          labels: [],
+          html_url: 'https://github.com/owner/test-repo/pull/99',
+        },
+        // Note: requested_reviewer can be undefined for team review requests
+      };
+
+      const ctx = buildWebhookContext(payload, 'pull_request', 'delivery-456', 'req-def');
+
+      expect(ctx.isReviewRequest).toBe(true);
+      expect(ctx.requestedReviewer).toBeUndefined();
+      expect(ctx.issue?.body).toBe(''); // null body converted to empty string
+    });
+
+    it('should handle review_requested with bot format username', () => {
+      const payload: GitHubWebhookPayload = {
+        ...basePayload,
+        action: 'review_requested',
+        pull_request: {
+          number: 99,
+          title: 'Add new feature',
+          body: 'Description',
+          state: 'open',
+          labels: [],
+          html_url: 'https://github.com/owner/test-repo/pull/99',
+        },
+        requested_reviewer: { login: 'duyetbot[bot]', id: 789 },
+      };
+
+      const ctx = buildWebhookContext(payload, 'pull_request', 'delivery-456', 'req-def');
+
+      expect(ctx.isReviewRequest).toBe(true);
+      expect(ctx.requestedReviewer).toBe('duyetbot[bot]');
+    });
+  });
+
+  describe('non-review PR events', () => {
+    it('should not set isReviewRequest for other PR events', () => {
+      const payload: GitHubWebhookPayload = {
+        ...basePayload,
+        action: 'opened',
+        pull_request: {
+          number: 99,
+          title: 'Add new feature',
+          body: 'Description',
+          state: 'open',
+          labels: [],
+          html_url: 'https://github.com/owner/test-repo/pull/99',
+        },
+      };
+
+      const ctx = buildWebhookContext(payload, 'pull_request', 'delivery-456', 'req-def');
+
+      expect(ctx.isPullRequest).toBe(true);
+      expect(ctx.isReviewRequest).toBeUndefined();
+      expect(ctx.requestedReviewer).toBeUndefined();
+    });
+  });
+});

--- a/apps/github-bot/src/index.ts
+++ b/apps/github-bot/src/index.ts
@@ -84,10 +84,13 @@ app.post(
 
     if (env.OBSERVABILITY_DB) {
       storage = new ObservabilityStorage(env.OBSERVABILITY_DB);
+      // Determine event type based on webhook context (will be updated after parser runs)
+      const webhookCtxForType = c.get('webhookContext');
+      const eventType = webhookCtxForType?.isReviewRequest ? 'review_request' : 'mention';
       collector = new EventCollector({
         eventId: crypto.randomUUID(),
         appSource: 'github-webhook',
-        eventType: 'mention',
+        eventType,
         triggeredAt: startTime,
         requestId,
       });

--- a/apps/github-bot/src/middlewares/types.ts
+++ b/apps/github-bot/src/middlewares/types.ts
@@ -177,6 +177,11 @@ export interface WebhookContext {
   headRef?: string;
   /** Target branch name */
   baseRef?: string;
+  // Review request metadata
+  /** Whether this is a review request event (pull_request:review_requested) */
+  isReviewRequest?: boolean;
+  /** Username of the requested reviewer (for review_requested events) */
+  requestedReviewer?: string;
 }
 
 /**
@@ -235,6 +240,8 @@ export interface GitHubWebhookPayload {
   comment?: GitHubComment;
   /** Hook ID (for ping events) */
   hook_id?: number;
+  /** Requested reviewer (for pull_request review_requested events) */
+  requested_reviewer?: GitHubUser;
 }
 
 /**


### PR DESCRIPTION
Add handling for `pull_request:review_requested` webhook event. When duyetbot is assigned as a PR reviewer, the agent automatically triggers to review the pull request without requiring an @mention.

Changes:
- Add `isReviewRequest` and `requestedReviewer` fields to WebhookContext
- Add `requested_reviewer` field to GitHubWebhookPayload
- Update parser to handle `pull_request:review_requested` events
- Update mention middleware to bypass mention check for reviewer requests
- Add tests for parser and mention middleware

## Summary by Sourcery

Support automatic PR review triggering when the bot is added as a requested reviewer via GitHub webhooks.

New Features:
- Trigger pull request review workflow when the bot is assigned as a reviewer on pull_request:review_requested events.

Enhancements:
- Extend webhook parsing to treat pull_request review_requested payloads as processable events and expose review request metadata in the webhook context.
- Update mention middleware to bypass mention detection and set an appropriate review task when the bot is the requested reviewer, while skipping processing when another user is requested.
- Adjust event collection to distinguish between mention-driven events and review-request-driven events in observability data.

Tests:
- Add unit tests covering parsing of pull_request:review_requested events and the mention middleware behavior for review request scenarios.