### PR TITLE
Initialize build environment setup

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -25,5 +25,5 @@
     "target": "ES2017"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vitest.config.ts"]
 }


### PR DESCRIPTION
Exclude vitest.config.ts from TypeScript type checking in the docs app to fix Next.js build failure caused by mergeConfig type incompatibility.