### PR TITLE
Add cost estimation utilities for token usage

### DIFF
--- a/apps/dashboard/app/api/tokens/summary/route.ts
+++ b/apps/dashboard/app/api/tokens/summary/route.ts
@@ -1,3 +1,4 @@
+import { estimateCostFromTokens } from '@duyetbot/analytics';
 import { NextRequest, NextResponse } from 'next/server';
 import { getDBFromContext } from '@/lib/db';
 import { handleRouteError, successResponse } from '../../types';
@@ -38,7 +39,10 @@ export async function GET(request: NextRequest) {
         totalOutputTokens: globalStats.totalOutputTokens,
         totalTokens: globalStats.totalTokens,
         platformBreakdown: globalStats.platformBreakdown,
-        estimatedCostUsd: 0, // TODO: Calculate from cost config
+        estimatedCostUsd: estimateCostFromTokens({
+          inputTokens: globalStats.totalInputTokens,
+          outputTokens: globalStats.totalOutputTokens,
+        }),
       })
     );
   } catch (error) {

--- a/packages/analytics/src/storage/aggregate-storage.ts
+++ b/packages/analytics/src/storage/aggregate-storage.ts
@@ -12,6 +12,7 @@
 
 import type { AggregateType, PeriodType } from '../types.js';
 import { BaseStorage } from './base.js';
+import { estimateCostFromTokens } from './cost-utils.js';
 
 /**
  * Token aggregate type
@@ -472,15 +473,25 @@ export class AggregateStorage extends BaseStorage {
       event_count: number;
     }>(sql, params);
 
+    const inputTokens = result?.input_tokens ?? 0;
+    const outputTokens = result?.output_tokens ?? 0;
+    const cachedTokens = result?.cached_tokens ?? 0;
+    const reasoningTokens = result?.reasoning_tokens ?? 0;
+
     return {
-      inputTokens: result?.input_tokens ?? 0,
-      outputTokens: result?.output_tokens ?? 0,
+      inputTokens,
+      outputTokens,
       totalTokens: result?.total_tokens ?? 0,
-      cachedTokens: result?.cached_tokens ?? 0,
-      reasoningTokens: result?.reasoning_tokens ?? 0,
+      cachedTokens,
+      reasoningTokens,
       messageCount: result?.message_count ?? 0,
       eventCount: result?.event_count ?? 0,
-      estimatedCostUsd: 0, // TODO: Calculate based on cost config
+      estimatedCostUsd: estimateCostFromTokens({
+        inputTokens,
+        outputTokens,
+        cachedTokens,
+        reasoningTokens,
+      }),
     };
   }
 

--- a/packages/analytics/src/storage/cost-utils.ts
+++ b/packages/analytics/src/storage/cost-utils.ts
@@ -1,0 +1,74 @@
+/**
+ * Cost Calculation Utilities
+ *
+ * Provides cost estimation for token usage when model-specific pricing
+ * is not available. Uses reasonable default rates based on common LLM pricing.
+ */
+
+/**
+ * Default pricing rates (USD per 1M tokens)
+ * These are conservative estimates based on typical LLM pricing as of 2024.
+ */
+export const DEFAULT_COST_RATES = {
+  /** Cost per 1M input tokens */
+  inputPerMillion: 1.0,
+  /** Cost per 1M output tokens */
+  outputPerMillion: 3.0,
+  /** Cost per 1M cached tokens */
+  cachedPerMillion: 0.1,
+  /** Cost per 1M reasoning tokens (similar to output) */
+  reasoningPerMillion: 3.0,
+};
+
+/**
+ * Token usage for cost calculation
+ */
+export interface TokenUsageForCostEstimate {
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens?: number;
+  reasoningTokens?: number;
+}
+
+/**
+ * Estimate cost for token usage using default rates
+ *
+ * Use this function when model-specific pricing is not available,
+ * such as when aggregating across multiple models or sessions.
+ *
+ * @param usage - Token usage breakdown
+ * @returns Estimated cost in USD
+ *
+ * @example
+ * ```typescript
+ * const cost = estimateCostFromTokens({
+ *   inputTokens: 10000,
+ *   outputTokens: 5000,
+ * });
+ * // cost = (10000 * 1.0 / 1_000_000) + (5000 * 3.0 / 1_000_000) = 0.025 USD
+ * ```
+ */
+export function estimateCostFromTokens(usage: TokenUsageForCostEstimate): number {
+  let cost = 0;
+
+  // Input tokens cost (non-cached)
+  const nonCachedInputTokens = usage.cachedTokens
+    ? Math.max(0, usage.inputTokens - usage.cachedTokens)
+    : usage.inputTokens;
+  cost += (nonCachedInputTokens * DEFAULT_COST_RATES.inputPerMillion) / 1_000_000;
+
+  // Output tokens cost
+  cost += (usage.outputTokens * DEFAULT_COST_RATES.outputPerMillion) / 1_000_000;
+
+  // Cached tokens cost (if present)
+  if (usage.cachedTokens && usage.cachedTokens > 0) {
+    cost += (usage.cachedTokens * DEFAULT_COST_RATES.cachedPerMillion) / 1_000_000;
+  }
+
+  // Reasoning tokens cost (if present)
+  if (usage.reasoningTokens && usage.reasoningTokens > 0) {
+    cost += (usage.reasoningTokens * DEFAULT_COST_RATES.reasoningPerMillion) / 1_000_000;
+  }
+
+  return cost;
+}

--- a/packages/analytics/src/storage/index.ts
+++ b/packages/analytics/src/storage/index.ts
@@ -7,4 +7,6 @@ export { AggregateStorage } from './aggregate-storage.js';
 export { BaseStorage } from './base.js';
 export { ConversationStorage } from './conversation-storage.js';
 export { CostConfigStorage } from './cost-config-storage.js';
+export type { TokenUsageForCostEstimate } from './cost-utils.js';
+export { DEFAULT_COST_RATES, estimateCostFromTokens } from './cost-utils.js';
 export { AnalyticsMessageStorage } from './message-storage.js';

--- a/packages/analytics/src/storage/message-storage.ts
+++ b/packages/analytics/src/storage/message-storage.ts
@@ -22,6 +22,7 @@ import type {
   UserStats,
 } from '../types.js';
 import { BaseStorage } from './base.js';
+import { estimateCostFromTokens } from './cost-utils.js';
 
 /**
  * AnalyticsMessageStorage handles D1 operations for analytics messages.
@@ -438,7 +439,10 @@ export class AnalyticsMessageStorage extends BaseStorage {
       totalInputTokens: result.total_input_tokens,
       totalOutputTokens: result.total_output_tokens,
       totalTokens: result.total_tokens,
-      estimatedCostUsd: 0, // TODO: Calculate based on cost config
+      estimatedCostUsd: estimateCostFromTokens({
+        inputTokens: result.total_input_tokens,
+        outputTokens: result.total_output_tokens,
+      }),
     };
   }
 


### PR DESCRIPTION
## Summary
This PR introduces cost estimation utilities for calculating USD costs based on token usage when model-specific pricing is not available. It replaces placeholder TODO comments with actual cost calculations across the analytics storage layer.

## Key Changes
- **New module**: `cost-utils.ts` provides:
  - `DEFAULT_COST_RATES` constant with conservative 2024 LLM pricing estimates (input: $1/1M tokens, output: $3/1M tokens, cached: $0.1/1M tokens, reasoning: $3/1M tokens)
  - `estimateCostFromTokens()` function to calculate estimated costs from token usage breakdowns
  - `TokenUsageForCostEstimate` interface for type-safe token usage input

- **Updated storage modules** to use the new cost estimation:
  - `AggregateStorage.getTokenStats()`: Now calculates `estimatedCostUsd` using token counts
  - `AnalyticsMessageStorage.getGlobalStats()`: Replaced TODO with actual cost calculation
  - `message-storage.ts` and `aggregate-storage.ts`: Import and utilize the new utility

- **API endpoint**: `apps/dashboard/app/api/tokens/summary/route.ts` now calculates estimated costs for the global token summary

- **Exports**: Added `estimateCostFromTokens` and `TokenUsageForCostEstimate` to the public analytics package API

## Implementation Details
- Cost calculation properly handles cached tokens by deducting them from input token costs (cached tokens are charged at a lower rate)
- Reasoning tokens are treated similarly to output tokens in cost calculation
- All optional token fields (cached, reasoning) are safely handled with existence checks
- Default rates are conservative estimates suitable for aggregation across multiple models when specific pricing is unavailable

https://claude.ai/code/session_018EyZWVvTNEikTw6VFbZkzc

## Summary by Sourcery

Introduce shared cost estimation utilities for token usage and wire them into analytics storage and token summary APIs to compute estimated USD costs.

New Features:
- Add a cost-utils module exposing default token pricing rates and a helper to estimate USD cost from token usage.
- Export the cost estimation helper and its token usage type from the analytics storage package for external consumers.

Enhancements:
- Update aggregate and message analytics storage to return estimated USD cost based on recorded token usage instead of placeholder values.
- Update the dashboard tokens summary API to include an estimated USD cost in the global token statistics response.